### PR TITLE
renamed xsl file to differentiate from AT version

### DIFF
--- a/ead-2-HTML.xsl
+++ b/ead-2-HTML.xsl
@@ -41,7 +41,7 @@
     -->
     
     <xsl:strip-space elements="*"/>
-    <xsl:output indent="yes" method="html" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" encoding="utf-8"/>
+    <xsl:output indent="yes" method="xml" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" encoding="utf-8"/>
 
 <!--    <xsl:include href="lookupLists.xsl"/>-->
     <!-- Creates the body of the finding aid.-->


### PR DESCRIPTION
This is the name of the xsl file as I've beenusing it on the library web server
I also changed the 'method=' from html to xml in the xsl:output -- otherwise it was displaying a bit of the xml header on the page.
