### PR TITLE
tweaks to make URLs relative and permanent

### DIFF
--- a/ead2html.xsl
+++ b/ead2html.xsl
@@ -119,7 +119,7 @@
 
     <!-- CSS for styling HTML output. Place all CSS styles in this template.-->
     <xsl:template name="css">
-        <link rel="stylesheet" type="text/css" href="https://draft-library.bowdoin.edu/arch/test/finding-aid.css" />
+        <link rel="stylesheet" type="text/css" href="/arch/libr/css/finding-aid.css" />
     </xsl:template>
 
     <!-- This template creates a customizable header  -->
@@ -209,7 +209,7 @@
         <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/collapse.js"></script>
         <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/transition.js"></script>
         <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/stickyfill.min.js"></script>
-        <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/test/finding-aid.js"></script>
+        <script type="text/javascript" src="/arch/libr/js/finding-aid.js"></script>
     </xsl:template>
 
     <!-- Template for Summary Information. Broken out so we can specify the order of children -->

--- a/ead2html.xsl
+++ b/ead2html.xsl
@@ -205,10 +205,10 @@
 
         <xsl:call-template name="site-footer-include"/>
 
-        <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/affix.js"></script>
-        <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/collapse.js"></script>
-        <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/transition.js"></script>
-        <script type="text/javascript" src="https://draft-library.bowdoin.edu/arch/libr/js/vendors/stickyfill.min.js"></script>
+        <script type="text/javascript" src="/arch/libr/js/vendors/affix.js"></script>
+        <script type="text/javascript" src="/arch/libr/js/vendors/collapse.js"></script>
+        <script type="text/javascript" src="/arch/libr/js/vendors/transition.js"></script>
+        <script type="text/javascript" src="/arch/libr/js/vendors/stickyfill.min.js"></script>
         <script type="text/javascript" src="/arch/libr/js/finding-aid.js"></script>
     </xsl:template>
 


### PR DESCRIPTION
I changed the paths of finding-aid.js and finding-aid.css to their permanent locations.
I also made some other javascript source ref URLs relative so they would work on both the draft and live server and pull the files from the current server.